### PR TITLE
Use `$http_host` instead of `$host`

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -29,7 +29,7 @@ http {
     gzip_proxied any;
     gzip_vary on;
 
-    log_format pypi_cache '$remote_addr - $host [$time_local] '
+    log_format pypi_cache '$remote_addr - $http_host [$time_local] '
                           'request_time=$request_time upstream_time=$upstream_response_time '
                           'cache_status=$upstream_cache_status \t'
                           '$status "$request" $body_bytes_sent';
@@ -66,8 +66,8 @@ http {
 
         # sub_filter can't apply to gzipped content, so be careful about that
         add_header X-Pypi-Cache $upstream_cache_status;
-        sub_filter 'https://pypi.org' $scheme://$host;
-        sub_filter 'https://files.pythonhosted.org/packages' $scheme://$host/packages;
+        sub_filter 'https://pypi.org' $scheme://$http_host;
+        sub_filter 'https://files.pythonhosted.org/packages' $scheme://$http_host/packages;
         sub_filter_once off;
         sub_filter_types application/vnd.pypi.simple.v1+json application/vnd.pypi.simple.v1+html;
 
@@ -80,7 +80,7 @@ http {
             proxy_set_header Host pypi.org;
             proxy_ssl_name pypi.org;
             proxy_pass https://sg_pypi;
-            proxy_redirect 'https://pypi.org' $scheme://$host;
+            proxy_redirect 'https://pypi.org' $scheme://$http_host;
         }
 
         location ^~ /simple {
@@ -92,7 +92,7 @@ http {
             proxy_set_header Host pypi.org;
             proxy_ssl_name pypi.org;
             proxy_pass https://sg_pypi;
-            proxy_redirect 'https://pypi.org' $scheme://$host;
+            proxy_redirect 'https://pypi.org' $scheme://$http_host;
         }
 
         location ^~ /packages {
@@ -104,7 +104,7 @@ http {
             proxy_set_header Host files.pythonhosted.org;
             proxy_ssl_name files.pythonhosted.org;
             proxy_pass 'https://sg_pythonhosted/packages';
-            proxy_redirect 'https://files.pythonhosted.org/packages' $scheme://$host/packages;
+            proxy_redirect 'https://files.pythonhosted.org/packages' $scheme://$http_host/packages;
         }
     }
 }


### PR DESCRIPTION
It looks like `$http_host` includes the port number when specified, and can be useful in some cases (e.g. local development)

(Carbon copy to @mattseddon because of https://github.com/iterative/itops/pull/4015)